### PR TITLE
Add `chdir` option to change current working directory

### DIFF
--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -10,13 +10,14 @@ import (
 )
 
 // execProdivedCmd executes a command along with its env variables
-func execProdivedCmd(tailArgs []string) (err error) {
+func execProdivedCmd(tailArgs []string, chdirPath string) (err error) {
 	cmdIn := tailArgs[0]
 	c, err := exec.LookPath(cmdIn)
 	if err != nil {
 		return fmt.Errorf("executable \"%s\" was not found\n%s", cmdIn, err)
 	}
 	cmd := exec.Command(c, tailArgs[1:]...)
+	cmd.Dir = chdirPath
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/cmd/envs_win.go
+++ b/cmd/envs_win.go
@@ -10,16 +10,17 @@ import (
 )
 
 // execProdivedCmd executes a command along with its env variables
-func execProdivedCmd(tArgs []string) (err error) {
+func execProdivedCmd(tailArgs []string, chdirPath string) (err error) {
 	ps, err := exec.LookPath("powershell.exe")
 	if err != nil {
 		return fmt.Errorf("executable \"powershell.exe\" was not found\n%s", err)
 	}
 	args := []string{"-NoProfile", "-NonInteractive", "-Command"}
 	args = append(args, "$ErrorActionPreference = \"Stop\"; ")
-	args = append(args, tArgs...)
+	args = append(args, tailArgs...)
 	args = append(args, "; if ($LastExitCode -gt 0) { exit $LastExitCode };")
 	cmd := exec.Command(ps, args...)
+	cmd.Dir = chdirPath
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This MR adds support for changing the current working directory via the new `--chdir, -c` option.

**Example**

```sh
$ mkdir -p /home/enve/bin
$ cd /home/enve
$ echo "ABC=123" > .env

$ enve --chdir ./bin bash -c "echo \$ABC; pwd"
# 123
# /home/enve/bin
```