### PR TITLE
Add `--new-environment, -n` option to start a new environment containing only variables from the `.env` file

### DIFF
--- a/cmd/envs.go
+++ b/cmd/envs.go
@@ -10,7 +10,7 @@ import (
 )
 
 // execProdivedCmd executes a command along with its env variables
-func execProdivedCmd(tailArgs []string, chdirPath string) (err error) {
+func execProdivedCmd(tailArgs []string, chdirPath string, newEnv bool, envVars []string) (err error) {
 	cmdIn := tailArgs[0]
 	c, err := exec.LookPath(cmdIn)
 	if err != nil {
@@ -18,6 +18,9 @@ func execProdivedCmd(tailArgs []string, chdirPath string) (err error) {
 	}
 	cmd := exec.Command(c, tailArgs[1:]...)
 	cmd.Dir = chdirPath
+	if newEnv {
+		cmd.Env = envVars
+	}
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/cmd/envs_win.go
+++ b/cmd/envs_win.go
@@ -10,7 +10,7 @@ import (
 )
 
 // execProdivedCmd executes a command along with its env variables
-func execProdivedCmd(tailArgs []string, chdirPath string) (err error) {
+func execProdivedCmd(tailArgs []string, chdirPath string, newEnv bool, envVars []string) (err error) {
 	ps, err := exec.LookPath("powershell.exe")
 	if err != nil {
 		return fmt.Errorf("executable \"powershell.exe\" was not found\n%s", err)
@@ -21,6 +21,9 @@ func execProdivedCmd(tailArgs []string, chdirPath string) (err error) {
 	args = append(args, "; if ($LastExitCode -gt 0) { exit $LastExitCode };")
 	cmd := exec.Command(ps, args...)
 	cmd.Dir = chdirPath
+	if newEnv {
+		cmd.Env = envVars
+	}
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This MR adds support for starting a _new environment_ containing only variables from the `.env` file and skipping the system ones via the new `--new-environment, -n` option.

**Example**

```sh
$ mkdir -p /home/enve/bin
$ cd /home/enve
$ echo "ABC=123" > .env

$ enve --new-environment -o text
# ABC=123
```