### PR TITLE
Add `--stdin, -s` option for reading environment variables from stdin

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -1,0 +1,86 @@
+package env
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+	"github.com/joseluisq/enve/fs"
+)
+
+// Environment defines JSON/XML data structure
+type Environment struct {
+	Env []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	} `json:"environment"`
+}
+
+type EnvFile interface {
+	Load(overload bool) error
+	Parse() (Map, error)
+	Close() error
+}
+
+type EnvReader interface {
+	Load(overload bool) error
+	Parse() (Map, error)
+}
+
+type Env struct {
+	r      io.Reader
+	closed bool
+}
+
+func FromReader(r io.Reader) EnvReader {
+	return &Env{r: r}
+}
+
+func FromPath(filePath string) (EnvFile, error) {
+	if err := fs.FileExists(filePath); err != nil {
+		return nil, err
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return &Env{r: f}, nil
+}
+
+func (e *Env) Load(overload bool) error {
+	envMap, err := e.Parse()
+	if err != nil {
+		return err
+	}
+
+	currentEnv := map[string]bool{}
+	rawEnv := os.Environ()
+	for _, rawEnvLine := range rawEnv {
+		key := strings.Split(rawEnvLine, "=")[0]
+		currentEnv[key] = true
+	}
+
+	for key, value := range envMap {
+		if !currentEnv[key] || overload {
+			_ = os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+func (e *Env) Parse() (Map, error) {
+	defer e.Close()
+	return godotenv.Parse(e.r)
+}
+
+func (e *Env) Close() error {
+	if !e.closed {
+		if f, ok := e.r.(*os.File); ok {
+			e.closed = true
+			return f.Close()
+		}
+	}
+	return nil
+}

--- a/env/map.go
+++ b/env/map.go
@@ -1,0 +1,15 @@
+package env
+
+import (
+	"fmt"
+)
+
+type Map map[string]string
+
+func (e Map) Array() []string {
+	vars := []string{}
+	for k, v := range e {
+		vars = append(vars, fmt.Sprintf("%s=%s", k, v))
+	}
+	return vars
+}

--- a/env/slice.go
+++ b/env/slice.go
@@ -1,0 +1,59 @@
+package env
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+type Slice []string
+
+func (e Slice) Text() string {
+	return strings.Join(e, "\n")
+}
+
+func (e Slice) Environ() (environ Environment, err error) {
+	str := ""
+	for i, s := range e {
+		pairs := strings.SplitN(s, "=", 2)
+		sep := ""
+		if i < len(e)-1 {
+			sep = ","
+		}
+		val := strings.ReplaceAll(pairs[1], "\"", "\\\"")
+		val = strings.ReplaceAll(val, "\n", "\\n")
+		val = strings.ReplaceAll(val, "\\", "\\\\")
+		val = strings.ReplaceAll(val, "\r", "\\r")
+		str += fmt.Sprintf("{\"name\":\"%s\",\"value\":\"%s\"}%s", pairs[0], val, sep)
+	}
+	jsonb := []byte("{\"environment\":[" + str + "]}")
+	if err := json.Unmarshal(jsonb, &environ); err != nil {
+		return environ, err
+	}
+	return environ, nil
+}
+
+func (e Slice) JSON() ([]byte, error) {
+	jsonenv, err := e.Environ()
+	if err != nil {
+		return []byte(nil), err
+	}
+	jsonb, err := json.Marshal(jsonenv)
+	if err != nil {
+		return []byte(nil), err
+	}
+	return jsonb, nil
+}
+
+func (e Slice) XML() ([]byte, error) {
+	jsonenv, err := e.Environ()
+	if err != nil {
+		return []byte(nil), err
+	}
+	xmlb, err := xml.Marshal(jsonenv)
+	if err != nil {
+		return []byte(nil), err
+	}
+	return xmlb, nil
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1,0 +1,34 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+)
+
+func FileExists(filePath string) error {
+	if filePath == "" {
+		return fmt.Errorf("file path was empty or not provided")
+	}
+	if info, err := os.Stat(filePath); err != nil {
+		return fmt.Errorf("cannot access file: %s; %v", filePath, err)
+	} else {
+		if info.IsDir() {
+			return fmt.Errorf("file path is a directory: %s", filePath)
+		}
+		return nil
+	}
+}
+
+func DirExists(dirPath string) error {
+	if dirPath == "" {
+		return fmt.Errorf("directory path was empty or not provided")
+	}
+	if info, err := os.Stat(dirPath); err != nil {
+		return fmt.Errorf("cannot access directory: %s; %v", dirPath, err)
+	} else {
+		if !info.IsDir() {
+			return fmt.Errorf("directory path is a file: %s", dirPath)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This MR adds support for reading environment variables from `stdin`. Note that if enabled, it will ignore the `.env` file.

**Examples**

```sh
$ echo -e 'LANG=es_PE.UTF-8\nEDITOR=emacs' | enve --stdin -w -o text
# TERM=xterm-256color
# EDITOR=emacs
# LANG=es_PE.UTF-8
# DISPLAY=:1

$ echo -e 'LANG=de_DE.UTF-8\nEDITOR=emacs' | enve --stdin -n -o json
# {"environment":[{"name":"LANG","value":"de_DE.UTF-8"},{"name":"EDITOR","value":"emacs"}]}

$ echo -e 'LANG=es_PE.UTF-8\nEDITOR=nano' | enve -s -n bash -c "env"
# EDITOR=nano
# PWD=/home/joseluisq/enve
# LANG=es_PE.UTF-8
# SHLVL=0
# _=/usr/bin/env
```